### PR TITLE
fix Travis CI build problems

### DIFF
--- a/scripts/travis/travis_install.sh
+++ b/scripts/travis/travis_install.sh
@@ -17,7 +17,7 @@ apt-get install \
     libatlas-dev libatlas-base-dev \
     libhdf5-serial-dev libgflags-dev libgoogle-glog-dev \
     bc \
-    libboost-thread-dev libboost-python-dev
+    libboost-thread-dev libboost-asio-dev
 
 # Add a special apt-repository to install CMake 2.8.9 for CMake Caffe build,
 # if needed.  By default, Aptitude in Ubuntu 12.04 installs CMake 2.8.7, but

--- a/scripts/travis/travis_install.sh
+++ b/scripts/travis/travis_install.sh
@@ -17,7 +17,7 @@ apt-get install \
     libatlas-dev libatlas-base-dev \
     libhdf5-serial-dev libgflags-dev libgoogle-glog-dev \
     bc \
-    libboost-thread-dev
+    libboost-thread-dev libboost-python-dev
 
 # Add a special apt-repository to install CMake 2.8.9 for CMake Caffe build,
 # if needed.  By default, Aptitude in Ubuntu 12.04 installs CMake 2.8.7, but

--- a/scripts/travis/travis_install.sh
+++ b/scripts/travis/travis_install.sh
@@ -17,7 +17,8 @@ apt-get install \
     libatlas-dev libatlas-base-dev \
     libhdf5-serial-dev libgflags-dev libgoogle-glog-dev \
     bc \
-    libboost-thread-dev libboost-asio-dev
+    libboost-all-dev
+    #libboost-thread-dev libboost-asio-dev
 
 # Add a special apt-repository to install CMake 2.8.9 for CMake Caffe build,
 # if needed.  By default, Aptitude in Ubuntu 12.04 installs CMake 2.8.7, but

--- a/scripts/travis/travis_install.sh
+++ b/scripts/travis/travis_install.sh
@@ -16,7 +16,8 @@ apt-get install \
     libprotobuf-dev protobuf-compiler \
     libatlas-dev libatlas-base-dev \
     libhdf5-serial-dev libgflags-dev libgoogle-glog-dev \
-    bc
+    bc \
+    libboost-thread-dev
 
 # Add a special apt-repository to install CMake 2.8.9 for CMake Caffe build,
 # if needed.  By default, Aptitude in Ubuntu 12.04 installs CMake 2.8.7, but


### PR DESCRIPTION
**_Please do not consider this pull request yet.  Please wait until it is successful in its goal, which is for Travis builds to succeed._**

Travis has not yet started building Caffe for me (i.e. in https://travis-ci.org/jeffhammond/caffe) so I am filing a PR so that it will start in the one associated with this repo.

I notice that all the Travis builds are failing (https://travis-ci.org/intelcaffe/caffe) due to the absence of the Boost::Threads header:
```
In file included from ./include/caffe/sgd_solvers.hpp:7:0,
                 from src/caffe/solvers/adagrad_solver.cpp:3:
./include/caffe/solver.hpp:3:30: fatal error: boost/function.hpp: No such file or directory
compilation terminated.
```