### PR TITLE
FCN support

### DIFF
--- a/include/caffe/layers/crop_layer.hpp
+++ b/include/caffe/layers/crop_layer.hpp
@@ -1,0 +1,49 @@
+#ifndef CAFFE_CROP_LAYER_HPP_
+#define CAFFE_CROP_LAYER_HPP_
+
+#include <utility>
+#include <vector>
+
+#include "caffe/blob.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/proto/caffe.pb.h"
+
+namespace caffe {
+
+/**
+ * @brief Takes a Blob and crop it along either the width or height dimension,
+ *        outputting a cropped Blob.
+ *
+ * TODO(dox): thorough documentation for Forward, Backward, and proto params.
+ */
+
+template <typename Dtype>
+class CropLayer : public Layer<Dtype> {
+ public:
+  explicit CropLayer(const LayerParameter& param)
+      : Layer<Dtype>(param) {}
+  virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+
+  virtual inline const char* type() const { return "Crop"; }
+  virtual inline int ExactNumBottomBlobs() const { return 2; }
+  virtual inline int ExactNumTopBlobs() const { return 1; }
+
+ protected:
+  virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+  virtual void Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+
+  int crop_h_, crop_w_;
+};
+
+}  // namespace caffe
+
+#endif  // CAFFE_CROP_LAYER_HPP_

--- a/include/caffe/layers/crop_layer.hpp
+++ b/include/caffe/layers/crop_layer.hpp
@@ -11,8 +11,8 @@
 namespace caffe {
 
 /**
- * @brief Takes a Blob and crop it along either the width or height dimension,
- *        outputting a cropped Blob.
+ * @brief Takes a Blob and crop it, to the shape specified by the second input
+ *  Blob, across all dimensions after the specified axis.
  *
  * TODO(dox): thorough documentation for Forward, Backward, and proto params.
  */

--- a/include/caffe/layers/crop_layer.hpp
+++ b/include/caffe/layers/crop_layer.hpp
@@ -41,9 +41,27 @@ class CropLayer : public Layer<Dtype> {
   virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
 
-  int crop_h_, crop_w_;
-};
+  vector<int> offsets;
 
+ private:
+  void crop_copy(const vector<Blob<Dtype>*>& bottom,
+               const vector<Blob<Dtype>*>& top,
+               const vector<int>& offsets,
+               vector<int> indices,
+               int cur_dim,
+               const Dtype* src_data,
+               Dtype* dest_data,
+               bool is_forward);
+
+  void crop_copy_gpu(const vector<Blob<Dtype>*>& bottom,
+                const vector<Blob<Dtype>*>& top,
+                const vector<int>& offsets,
+                vector<int> indices,
+                int cur_dim,
+                const Dtype* src_data,
+                Dtype* dest_data,
+                bool is_forward);
+};
 }  // namespace caffe
 
 #endif  // CAFFE_CROP_LAYER_HPP_

--- a/python/caffe/coord_map.py
+++ b/python/caffe/coord_map.py
@@ -1,0 +1,95 @@
+from __future__ import division
+import numpy as np
+from caffe import layers as L
+
+PASS_THROUGH_LAYERS = ['AbsVal', 'ReLU', 'PReLU', 'Dropout', 'LRN', 'Eltwise',
+        'BatchNorm', 'BNLL', 'Log', 'Exp', 'MVN', 'Power', 'Sigmoid', 'Split',
+        'TanH', 'Threshold']
+
+def conv_params(fn):
+    params = fn.params.get('convolution_param', fn.params)
+    axis = params.get('axis', 1)
+    ks = np.array(params['kernel_size'], ndmin=1)
+    dilation = np.array(params.get('dilation', 1), ndmin=1)
+    assert len({'pad_h', 'pad_w', 'kernel_h', 'kernel_w', 'stride_h',
+        'stride_w'} & set(fn.params)) == 0, \
+                'cropping does not support legacy _h/_w params'
+    return (axis, np.array(params.get('stride', 1), ndmin=1),
+            (ks - 1) * dilation + 1,
+            np.array(params.get('pad', 0), ndmin=1))
+
+class UndefinedMapException(Exception):
+    pass
+
+def coord_map(fn):
+    if fn.type_name in ['Convolution', 'Pooling', 'Im2col']:
+        axis, stride, ks, pad = conv_params(fn)
+        return axis, 1 / stride, (pad - (ks - 1) / 2) / stride
+    elif fn.type_name == 'Deconvolution':
+        axis, stride, ks, pad = conv_params(fn)
+        return axis, stride, (ks - 1) / 2 - pad
+    elif fn.type_name in PASS_THROUGH_LAYERS:
+        return None, 1, 0
+    elif fn.type_name == 'Crop':
+        axis = fn.params.get('axis')
+        return axis, 1, - fn.params['crop']
+    else:
+        raise UndefinedMapException
+
+class AxisMismatchException(Exception):
+    pass
+
+def compose((ax1, a1, b1), (ax2, a2, b2)):
+    if ax1 is None:
+        ax = ax2
+    elif ax2 is None or ax1 == ax2:
+        ax = ax1
+    else:
+        raise AxisMismatchException
+    return ax, a1 * a2, a1 * b2 + b1
+
+def inverse((ax, a, b)):
+    return ax, 1 / a, -b / a
+
+def coord_map_from_to(top_from, top_to):
+    # We need to find a common ancestor of top_from and top_to.
+    # We'll assume that all ancestors are equivalent here (otherwise the graph
+    # is an inconsistent state (which we could improve this to check for)).
+    # For now use a brute-force algorithm.
+
+    # walk back from top_from, keeping the coord map as we go
+    from_maps = {top_from: (None, 1, 0)}
+    frontier = {top_from}
+    while frontier:
+        top = frontier.pop()
+        try:
+            for bottom in top.fn.inputs:
+                from_maps[bottom] = compose(from_maps[top], coord_map(top.fn))
+                frontier.add(bottom)
+        except UndefinedMapException:
+            pass
+
+    # now walk back from top_to until we hit a common blob
+    to_maps = {top_to: (None, 1, 0)}
+    frontier = {top_to}
+    while frontier:
+        top = frontier.pop()
+        if top in from_maps:
+            return compose(to_maps[top], inverse(from_maps[top]))
+        try:
+            for bottom in top.fn.inputs:
+                to_maps[bottom] = compose(to_maps[top], coord_map(top.fn))
+                frontier.add(bottom)
+        except UndefinedMapException:
+            continue
+
+    # if we got here, we did not find a blob in common
+    raise RuntimeError, 'Could not compute map between tops; are they connected ' \
+            'by spatial layers?'
+
+def crop(top_from, top_to):
+    ax, a, b = coord_map_from_to(top_from, top_to)
+    assert (a == 1).all(), 'scale mismatch on crop (a = {})'.format(a)
+    assert (b <= 0).all(), 'cannot crop negative width (b = {})'.format(b)
+    assert (np.round(b) == b).all(), 'cannot crop noninteger width (b = {})'.format(b)
+    return L.Crop(top_from, top_to, crop_param=dict(axis=ax, crop=list(-np.round(b).astype(int))))

--- a/python/caffe/coord_map.py
+++ b/python/caffe/coord_map.py
@@ -73,6 +73,7 @@ def coord_map(fn):
         return None, 1, 0
     elif fn.type_name == 'Crop':
         axis, offset = crop_params(fn)
+        axis -= 1  # -1 for last non-coordinate dim.
         return axis, 1, - offset
     else:
         raise UndefinedMapException
@@ -176,9 +177,9 @@ def crop(top_from, top_to):
     """
     ax, a, b = coord_map_from_to(top_from, top_to)
     assert (a == 1).all(), 'scale mismatch on crop (a = {})'.format(a)
-    assert (b <= 0).all(), 'cannot crop negative width (b = {})'.format(b)
-    assert (np.round(b) == b).all(), 'cannot crop noninteger width ' \
+    assert (b <= 0).all(), 'cannot crop negative offset (b = {})'.format(b)
+    assert (np.round(b) == b).all(), 'cannot crop noninteger offset ' \
         '(b = {})'.format(b)
     return L.Crop(top_from, top_to,
-                  crop_param=dict(axis=ax,
-                                  crop=list(-np.round(b).astype(int))))
+                  crop_param=dict(axis=ax + 1,  # +1 for first cropping dim.
+                                  offset=list(-np.round(b).astype(int))))

--- a/python/caffe/coord_map.py
+++ b/python/caffe/coord_map.py
@@ -1,27 +1,68 @@
+"""
+Determine spatial relationships between layers to relate their coordinates.
+Coordinates are mapped from input-to-output (forward), but can
+be mapped output-to-input (backward) by the inverse mapping too.
+This helps crop and align feature maps among other uses.
+"""
+
 from __future__ import division
 import numpy as np
 from caffe import layers as L
 
-PASS_THROUGH_LAYERS = ['AbsVal', 'ReLU', 'PReLU', 'Dropout', 'LRN', 'Eltwise',
-        'BatchNorm', 'BNLL', 'Log', 'Exp', 'MVN', 'Power', 'Sigmoid', 'Split',
-        'TanH', 'Threshold']
+PASS_THROUGH_LAYERS = ['AbsVal', 'BatchNorm', 'Bias', 'BNLL', 'Dropout',
+                       'Eltwise', 'ELU', 'Log', 'LRN', 'Exp', 'MVN', 'Power',
+                       'ReLU', 'PReLU', 'Scale', 'Sigmoid', 'Split', 'TanH',
+                       'Threshold']
+
 
 def conv_params(fn):
+    """
+    Extract the spatial parameters that determine the coordinate mapping:
+    kernel size, stride, padding, and dilation.
+
+    Implementation detail: Convolution, Deconvolution, and Im2col layers
+    define these in the convolution_param message, while Pooling has its
+    own fields in pooling_param. This method deals with these details to
+    extract canonical parameters.
+    """
     params = fn.params.get('convolution_param', fn.params)
     axis = params.get('axis', 1)
     ks = np.array(params['kernel_size'], ndmin=1)
     dilation = np.array(params.get('dilation', 1), ndmin=1)
     assert len({'pad_h', 'pad_w', 'kernel_h', 'kernel_w', 'stride_h',
-        'stride_w'} & set(fn.params)) == 0, \
-                'cropping does not support legacy _h/_w params'
+                'stride_w'} & set(fn.params)) == 0, \
+        'cropping does not support legacy _h/_w params'
     return (axis, np.array(params.get('stride', 1), ndmin=1),
             (ks - 1) * dilation + 1,
             np.array(params.get('pad', 0), ndmin=1))
 
+
+def crop_params(fn):
+    """
+    Extract the crop layer parameters with defaults.
+    """
+    params = fn.params.get('crop_param', fn.params)
+    axis = params.get('axis', 2)  # default to spatial crop for N, C, H, W
+    offset = np.array(params.get('offset', 0), ndmin=1)
+    return (axis, offset)
+
+
 class UndefinedMapException(Exception):
+    """
+    Exception raised for layers that do not have a defined coordinate mapping.
+    """
     pass
 
+
 def coord_map(fn):
+    """
+    Define the coordinate mapping by its
+    - axis
+    - scale: output coord[i * scale] <- input_coord[i]
+    - shift: output coord[i] <- output_coord[i + shift]
+    s.t. the identity mapping, as for pointwise layers like ReLu, is defined by
+    (None, 1, 0) since it is independent of axis and does not transform coords.
+    """
     if fn.type_name in ['Convolution', 'Pooling', 'Im2col']:
         axis, stride, ks, pad = conv_params(fn)
         return axis, 1 / stride, (pad - (ks - 1) / 2) / stride
@@ -31,15 +72,27 @@ def coord_map(fn):
     elif fn.type_name in PASS_THROUGH_LAYERS:
         return None, 1, 0
     elif fn.type_name == 'Crop':
-        axis = fn.params.get('axis')
-        return axis, 1, - fn.params['crop']
+        axis, offset = crop_params(fn)
+        return axis, 1, - offset
     else:
         raise UndefinedMapException
 
+
 class AxisMismatchException(Exception):
+    """
+    Exception raised for mappings with incompatible axes.
+    """
     pass
 
-def compose((ax1, a1, b1), (ax2, a2, b2)):
+
+def compose(base_map, next_map):
+    """
+    Compose a base coord map with scale a1, shift b1 with a further coord map
+    with scale a2, shift b2. The scales multiply and the further shift, b2,
+    is scaled by base coord scale a1.
+    """
+    ax1, a1, b1 = base_map
+    ax2, a2, b2 = next_map
     if ax1 is None:
         ax = ax2
     elif ax2 is None or ax1 == ax2:
@@ -48,14 +101,39 @@ def compose((ax1, a1, b1), (ax2, a2, b2)):
         raise AxisMismatchException
     return ax, a1 * a2, a1 * b2 + b1
 
-def inverse((ax, a, b)):
+
+def inverse(coord_map):
+    """
+    Invert a coord map by de-scaling and un-shifting;
+    this gives the backward mapping for the gradient.
+    """
+    ax, a, b = coord_map
     return ax, 1 / a, -b / a
 
+
 def coord_map_from_to(top_from, top_to):
+    """
+    Determine the coordinate mapping betweeen a top (from) and a top (to).
+    Walk the graph to find a common ancestor while composing the coord maps for
+    from and to until they meet. As a last step the from map is inverted.
+    """
     # We need to find a common ancestor of top_from and top_to.
     # We'll assume that all ancestors are equivalent here (otherwise the graph
     # is an inconsistent state (which we could improve this to check for)).
     # For now use a brute-force algorithm.
+
+    def collect_bottoms(top):
+        """
+        Collect the bottoms to walk for the coordinate mapping.
+        The general rule is that all the bottoms of a layer can be mapped, as
+        most layers have the same coordinate mapping for each bottom.
+        Crop layer is a notable exception. Only the first/cropped bottom is
+        mappable; the second/dimensions bottom is excluded from the walk.
+        """
+        bottoms = top.fn.inputs
+        if top.fn.type_name == 'Crop':
+            bottoms = bottoms[:1]
+        return bottoms
 
     # walk back from top_from, keeping the coord map as we go
     from_maps = {top_from: (None, 1, 0)}
@@ -63,7 +141,8 @@ def coord_map_from_to(top_from, top_to):
     while frontier:
         top = frontier.pop()
         try:
-            for bottom in top.fn.inputs:
+            bottoms = collect_bottoms(top)
+            for bottom in bottoms:
                 from_maps[bottom] = compose(from_maps[top], coord_map(top.fn))
                 frontier.add(bottom)
         except UndefinedMapException:
@@ -77,19 +156,29 @@ def coord_map_from_to(top_from, top_to):
         if top in from_maps:
             return compose(to_maps[top], inverse(from_maps[top]))
         try:
-            for bottom in top.fn.inputs:
+            bottoms = collect_bottoms(top)
+            for bottom in bottoms:
                 to_maps[bottom] = compose(to_maps[top], coord_map(top.fn))
                 frontier.add(bottom)
         except UndefinedMapException:
             continue
 
     # if we got here, we did not find a blob in common
-    raise RuntimeError, 'Could not compute map between tops; are they connected ' \
-            'by spatial layers?'
+    raise RuntimeError('Could not compute map between tops; are they '
+                       'connected by spatial layers?')
+
 
 def crop(top_from, top_to):
+    """
+    Define a Crop layer to crop a top (from) to another top (to) by
+    determining the coordinate mapping between the two and net spec'ing
+    the axis and shift parameters of the crop.
+    """
     ax, a, b = coord_map_from_to(top_from, top_to)
     assert (a == 1).all(), 'scale mismatch on crop (a = {})'.format(a)
     assert (b <= 0).all(), 'cannot crop negative width (b = {})'.format(b)
-    assert (np.round(b) == b).all(), 'cannot crop noninteger width (b = {})'.format(b)
-    return L.Crop(top_from, top_to, crop_param=dict(axis=ax, crop=list(-np.round(b).astype(int))))
+    assert (np.round(b) == b).all(), 'cannot crop noninteger width ' \
+        '(b = {})'.format(b)
+    return L.Crop(top_from, top_to,
+                  crop_param=dict(axis=ax,
+                                  crop=list(-np.round(b).astype(int))))

--- a/python/caffe/test/test_coord_map.py
+++ b/python/caffe/test/test_coord_map.py
@@ -1,0 +1,192 @@
+import unittest
+
+import numpy as np
+import random
+
+import caffe
+from caffe import layers as L
+from caffe import params as P
+from caffe.coord_map import coord_map_from_to, crop
+
+
+def coord_net_spec(ks=3, stride=1, pad=0, pool=2, dstride=2, dpad=0):
+    """
+    Define net spec for simple conv-pool-deconv pattern common to all
+    coordinate mapping tests.
+    """
+    n = caffe.NetSpec()
+    n.data = L.Input(shape=dict(dim=[2, 1, 100, 100]))
+    n.aux = L.Input(shape=dict(dim=[2, 1, 20, 20]))
+    n.conv = L.Convolution(
+        n.data, num_output=10, kernel_size=ks, stride=stride, pad=pad)
+    n.pool = L.Pooling(
+        n.conv, pool=P.Pooling.MAX, kernel_size=pool, stride=pool, pad=0)
+    # for upsampling kernel size is 2x stride
+    try:
+        deconv_ks = [s*2 for s in dstride]
+    except:
+        deconv_ks = dstride*2
+    n.deconv = L.Deconvolution(
+        n.pool, num_output=10, kernel_size=deconv_ks, stride=dstride, pad=dpad)
+    return n
+
+
+class TestCoordMap(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_conv_pool_deconv(self):
+        """
+        Map through conv, pool, and deconv.
+        """
+        n = coord_net_spec()
+        # identity for 2x pool, 2x deconv
+        ax, a, b = coord_map_from_to(n.deconv, n.data)
+        self.assertEquals(ax, 1)
+        self.assertEquals(a, 1)
+        self.assertEquals(b, 0)
+        # shift-by-one for 4x pool, 4x deconv
+        n = coord_net_spec(pool=4, dstride=4)
+        ax, a, b = coord_map_from_to(n.deconv, n.data)
+        self.assertEquals(ax, 1)
+        self.assertEquals(a, 1)
+        self.assertEquals(b, -1)
+
+    def test_pass(self):
+        """
+        A pass-through layer (ReLU) and conv (1x1, stride 1, pad 0)
+        both do identity mapping.
+        """
+        n = coord_net_spec()
+        ax, a, b = coord_map_from_to(n.deconv, n.data)
+        n.relu = L.ReLU(n.deconv)
+        n.conv1x1 = L.Convolution(
+            n.relu, num_output=10, kernel_size=1, stride=1, pad=0)
+        for top in [n.relu, n.conv1x1]:
+            ax_pass, a_pass, b_pass = coord_map_from_to(top, n.data)
+            self.assertEquals(ax, ax_pass)
+            self.assertEquals(a, a_pass)
+            self.assertEquals(b, b_pass)
+
+    def test_padding(self):
+        """
+        Padding conv adds offset while padding deconv subtracts offset.
+        """
+        n = coord_net_spec()
+        ax, a, b = coord_map_from_to(n.deconv, n.data)
+        pad = random.randint(0, 10)
+        # conv padding
+        n = coord_net_spec(pad=pad)
+        _, a_pad, b_pad = coord_map_from_to(n.deconv, n.data)
+        self.assertEquals(a, a_pad)
+        self.assertEquals(b - pad, b_pad)
+        # deconv padding
+        n = coord_net_spec(dpad=pad)
+        _, a_pad, b_pad = coord_map_from_to(n.deconv, n.data)
+        self.assertEquals(a, a_pad)
+        self.assertEquals(b + pad, b_pad)
+        # pad both to cancel out
+        n = coord_net_spec(pad=pad, dpad=pad)
+        _, a_pad, b_pad = coord_map_from_to(n.deconv, n.data)
+        self.assertEquals(a, a_pad)
+        self.assertEquals(b, b_pad)
+
+    def test_multi_conv(self):
+        """
+        Multiple bottoms/tops of a layer are identically mapped.
+        """
+        n = coord_net_spec()
+        # multi bottom/top
+        n.conv_data, n.conv_aux = L.Convolution(
+            n.data, n.aux, ntop=2, num_output=10, kernel_size=5, stride=2,
+            pad=0)
+        ax1, a1, b1 = coord_map_from_to(n.conv_data, n.data)
+        ax2, a2, b2 = coord_map_from_to(n.conv_aux, n.aux)
+        self.assertEquals(ax1, ax2)
+        self.assertEquals(a1, a2)
+        self.assertEquals(b1, b2)
+
+    def test_rect(self):
+        """
+        Anisotropic mapping is equivalent to its isotropic parts.
+        """
+        n3x3 = coord_net_spec(ks=3, stride=1, pad=0)
+        n5x5 = coord_net_spec(ks=5, stride=2, pad=10)
+        n3x5 = coord_net_spec(ks=[3, 5], stride=[1, 2], pad=[0, 10])
+        ax_3x3, a_3x3, b_3x3 = coord_map_from_to(n3x3.deconv, n3x3.data)
+        ax_5x5, a_5x5, b_5x5 = coord_map_from_to(n5x5.deconv, n5x5.data)
+        ax_3x5, a_3x5, b_3x5 = coord_map_from_to(n3x5.deconv, n3x5.data)
+        self.assertTrue(ax_3x3 == ax_5x5 == ax_3x5)
+        self.assertEquals(a_3x3, a_3x5[0])
+        self.assertEquals(b_3x3, b_3x5[0])
+        self.assertEquals(a_5x5, a_3x5[1])
+        self.assertEquals(b_5x5, b_3x5[1])
+
+    def test_nd_conv(self):
+        """
+        ND conv maps the same way in more dimensions.
+        """
+        n = caffe.NetSpec()
+        # define data with 3 spatial dimensions, otherwise the same net
+        n.data = L.Input(shape=dict(dim=[2, 3, 100, 100, 100]))
+        n.conv = L.Convolution(
+            n.data, num_output=10, kernel_size=[3, 3, 3], stride=[1, 1, 1],
+            pad=[0, 1, 2])
+        n.pool = L.Pooling(
+            n.conv, pool=P.Pooling.MAX, kernel_size=2, stride=2, pad=0)
+        n.deconv = L.Deconvolution(
+            n.pool, num_output=10, kernel_size=4, stride=2, pad=0)
+        ax, a, b = coord_map_from_to(n.deconv, n.data)
+        self.assertEquals(ax, 1)
+        self.assertTrue(len(a) == len(b))
+        self.assertTrue(np.all(a == 1))
+        self.assertEquals(b[0] - 1, b[1])
+        self.assertEquals(b[1] - 1, b[2])
+
+    def test_crop_of_crop(self):
+        """
+        Map coordinates through Crop layer:
+        crop an already-cropped output to the input and check change in offset.
+        """
+        n = coord_net_spec()
+        offset = random.randint(0, 10)
+        ax, a, b = coord_map_from_to(n.deconv, n.data)
+        n.crop = L.Crop(n.deconv, n.data, axis=2, offset=offset)
+        ax_crop, a_crop, b_crop = coord_map_from_to(n.crop, n.data)
+        self.assertEquals(ax, ax_crop)
+        self.assertEquals(a, a_crop)
+        self.assertEquals(b + offset, b_crop)
+
+    def test_crop_helper(self):
+        """
+        Define Crop layer by crop().
+        """
+        n = coord_net_spec()
+        crop(n.deconv, n.data)
+
+    def test_catch_unconnected(self):
+        """
+        Catch mapping spatially unconnected tops.
+        """
+        n = coord_net_spec()
+        n.ip = L.InnerProduct(n.deconv, num_output=10)
+        with self.assertRaises(RuntimeError):
+            coord_map_from_to(n.ip, n.data)
+
+    def test_catch_scale_mismatch(self):
+        """
+        Catch incompatible scales, such as when the top to be cropped
+        is mapped to a differently strided reference top.
+        """
+        n = coord_net_spec(pool=3, dstride=2)  # pool 3x but deconv 2x
+        with self.assertRaises(AssertionError):
+            crop(n.deconv, n.data)
+
+    def test_catch_negative_crop(self):
+        """
+        Catch impossible offsets, such as when the top to be cropped
+        is mapped to a larger reference top.
+        """
+        n = coord_net_spec(dpad=10)  # make output smaller than input
+        with self.assertRaises(AssertionError):
+            crop(n.deconv, n.data)

--- a/src/caffe/layers/crop_layer.cpp
+++ b/src/caffe/layers/crop_layer.cpp
@@ -1,0 +1,78 @@
+#include <algorithm>
+#include <map>
+#include <set>
+#include <vector>
+
+#include "caffe/layer.hpp"
+#include "caffe/layers/crop_layer.hpp"
+#include "caffe/net.hpp"
+
+
+namespace caffe {
+
+template <typename Dtype>
+void CropLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top) {
+  const CropParameter& param = this->layer_param_.crop_param();
+  CHECK_EQ(bottom.size(), 2) << "Wrong number of bottom blobs.";
+  CHECK_EQ(bottom[0]->num_axes(), 4) << "Only works with 4D blobs.";
+  CHECK_EQ(bottom[1]->num_axes(), 4) << "Only works with 4D blobs.";
+  crop_h_ = param.offset_height();
+  crop_w_ = param.offset_width();
+}
+
+template <typename Dtype>
+void CropLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top) {
+  // Check that the image we are cropping minus the margin is bigger than the
+  // destination image.
+  CHECK_GT(bottom[0]->height()-crop_h_, bottom[1]->height())
+      << "invalid offset";
+  CHECK_GT(bottom[0]->width()-crop_w_, bottom[1]->width()) << "invalid offset";
+  top[0]->Reshape(bottom[0]->num(), bottom[0]->channels(), bottom[1]->height(),
+      bottom[1]->width());
+}
+
+template <typename Dtype>
+void CropLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top) {
+  const Dtype* bottom_data = bottom[0]->cpu_data();
+  Dtype* top_data = top[0]->mutable_cpu_data();
+  for (int n = 0; n < top[0]->num(); ++n) {
+    for (int c = 0; c < top[0]->channels(); ++c) {
+      for (int h = 0; h < top[0]->height(); ++h) {
+        caffe_copy(top[0]->width(),
+            bottom_data + bottom[0]->offset(n, c, crop_h_ + h, crop_w_),
+            top_data + top[0]->offset(n, c, h));
+      }
+    }
+  }
+}
+
+template <typename Dtype>
+void CropLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
+    const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+  const Dtype* top_diff = top[0]->cpu_diff();
+  Dtype* bottom_diff = bottom[0]->mutable_cpu_diff();
+  if (propagate_down[0]) {
+    caffe_set(bottom[0]->count(), static_cast<Dtype>(0), bottom_diff);
+    for (int n = 0; n < top[0]->num(); ++n) {
+      for (int c = 0; c < top[0]->channels(); ++c) {
+        for (int h = 0; h < top[0]->height(); ++h) {
+          caffe_copy(top[0]->width(),
+              top_diff + top[0]->offset(n, c, h),
+              bottom_diff + bottom[0]->offset(n, c, crop_h_ + h, crop_w_));
+        }
+      }
+    }
+  }
+}
+
+#ifdef CPU_ONLY
+STUB_GPU(CropLayer);
+#endif
+
+INSTANTIATE_CLASS(CropLayer);
+REGISTER_LAYER_CLASS(Crop);
+
+}  // namespace caffe

--- a/src/caffe/layers/crop_layer.cpp
+++ b/src/caffe/layers/crop_layer.cpp
@@ -1,7 +1,9 @@
 #include <algorithm>
+#include <functional>
 #include <map>
 #include <set>
 #include <vector>
+
 
 #include "caffe/layer.hpp"
 #include "caffe/layers/crop_layer.hpp"
@@ -13,40 +15,108 @@ namespace caffe {
 template <typename Dtype>
 void CropLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
     const vector<Blob<Dtype>*>& top) {
-  const CropParameter& param = this->layer_param_.crop_param();
   CHECK_EQ(bottom.size(), 2) << "Wrong number of bottom blobs.";
-  CHECK_EQ(bottom[0]->num_axes(), 4) << "Only works with 4D blobs.";
-  CHECK_EQ(bottom[1]->num_axes(), 4) << "Only works with 4D blobs.";
-  crop_h_ = param.offset_height();
-  crop_w_ = param.offset_width();
+  // parameter setup moved to Reshape because it depends on size.
 }
 
 template <typename Dtype>
 void CropLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
     const vector<Blob<Dtype>*>& top) {
-  // Check that the image we are cropping minus the margin is bigger than the
-  // destination image.
-  CHECK_GT(bottom[0]->height()-crop_h_, bottom[1]->height())
-      << "invalid offset";
-  CHECK_GT(bottom[0]->width()-crop_w_, bottom[1]->width()) << "invalid offset";
-  top[0]->Reshape(bottom[0]->num(), bottom[0]->channels(), bottom[1]->height(),
-      bottom[1]->width());
+  const CropParameter& param = this->layer_param_.crop_param();
+  // bottom[0] supplies the data
+  // bottom[1] supplies the size
+  int input_dim = bottom[0]->num_axes();
+  CHECK_LT(param.axis(), input_dim) << "crop axis bigger than input dim";
+  // initialize all offsets to 0
+  offsets = vector<int>(input_dim, 0);
+  // initialize new shape to bottom[0]
+  vector<int> new_shape(bottom[0]->shape());
+
+  if (param.offset_size() > 1) {
+    // the number of crop values specified must be equal to the number
+    // of dimensions following axis
+    CHECK_EQ(param.axis() + param.offset_size(), input_dim)
+      << "number of crop values specified must be equal to the number of "
+      << "dimensions following axis.";
+  }
+  // apply crops
+  for (int i = 0; i < input_dim; ++i) {
+    int crop_offset = 0;
+    int new_size    = bottom[0]->shape(i);
+    if (i >= param.axis() && param.offset_size() == 1) {
+      // if only one crop value is supplied, crop all dimensions after axis
+      // by this crop value
+      crop_offset = param.offset(0);
+      new_size = bottom[1]->shape(i);
+    } else if (i >= param.axis() && param.offset_size() > 1) {
+      // crop values specified must be equal to the number of dimensions
+      // following axis
+      crop_offset = param.offset(i - param.axis());
+      new_size = bottom[1]->shape(i);
+    }
+    // Check that the image we are cropping minus the margin is bigger
+    // than the destination image.
+    CHECK_GE(bottom[0]->shape(i) - crop_offset,
+             bottom[1]->shape(i))
+        << "invalid crop parameters in dimension: " << i;
+    // Now set new size and offsets
+    new_shape[i] = new_size;
+    offsets[i] = crop_offset;
+  }
+  top[0]->Reshape(new_shape);
+}
+
+// recursive copy function
+template <typename Dtype>
+void CropLayer<Dtype>::crop_copy(const vector<Blob<Dtype>*>& bottom,
+             const vector<Blob<Dtype>*>& top,
+             const vector<int>& offsets,
+             vector<int> indices,
+             int cur_dim,
+             const Dtype* src_data,
+             Dtype* dest_data,
+             bool is_forward) {
+  if (cur_dim + 1 < top[0]->num_axes()) {
+    // We are not yet at the final dimension, call copy recursivley
+    for (int i = 0; i < top[0]->shape(cur_dim); ++i) {
+      indices[cur_dim] = i;
+      crop_copy(bottom, top, offsets, indices, cur_dim+1,
+                src_data, dest_data, is_forward);
+    }
+  } else {
+    // We are at the last dimensions, which is stored continously in memory
+    for (int i = 0; i < top[0]->shape(cur_dim); ++i) {
+      // prepare index vector reduced(red) and with offsets(off)
+      std::vector<int> ind_red(cur_dim, 0);
+      std::vector<int> ind_off(cur_dim+1, 0);
+      for (int j = 0; j < cur_dim; ++j) {
+          ind_red[j] = indices[j];
+          ind_off[j] = indices[j] + offsets[j];
+      }
+      ind_off[cur_dim] = offsets[cur_dim];
+      // do the copy
+      if (is_forward) {
+        caffe_copy(top[0]->shape(cur_dim),
+            src_data + bottom[0]->offset(ind_off),
+            dest_data + top[0]->offset(ind_red));
+      } else {
+        // in the backwards pass the src_data is top_diff
+        // and the dest_data is bottom_diff
+        caffe_copy(top[0]->shape(cur_dim),
+            src_data + top[0]->offset(ind_red),
+            dest_data + bottom[0]->offset(ind_off));
+      }
+    }
+  }
 }
 
 template <typename Dtype>
 void CropLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
     const vector<Blob<Dtype>*>& top) {
+  std::vector<int> indices(top[0]->num_axes(), 0);
   const Dtype* bottom_data = bottom[0]->cpu_data();
   Dtype* top_data = top[0]->mutable_cpu_data();
-  for (int n = 0; n < top[0]->num(); ++n) {
-    for (int c = 0; c < top[0]->channels(); ++c) {
-      for (int h = 0; h < top[0]->height(); ++h) {
-        caffe_copy(top[0]->width(),
-            bottom_data + bottom[0]->offset(n, c, crop_h_ + h, crop_w_),
-            top_data + top[0]->offset(n, c, h));
-      }
-    }
-  }
+  crop_copy(bottom, top, offsets, indices, 0, bottom_data, top_data, true);
 }
 
 template <typename Dtype>
@@ -54,17 +124,11 @@ void CropLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
     const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
   const Dtype* top_diff = top[0]->cpu_diff();
   Dtype* bottom_diff = bottom[0]->mutable_cpu_diff();
+
   if (propagate_down[0]) {
     caffe_set(bottom[0]->count(), static_cast<Dtype>(0), bottom_diff);
-    for (int n = 0; n < top[0]->num(); ++n) {
-      for (int c = 0; c < top[0]->channels(); ++c) {
-        for (int h = 0; h < top[0]->height(); ++h) {
-          caffe_copy(top[0]->width(),
-              top_diff + top[0]->offset(n, c, h),
-              bottom_diff + bottom[0]->offset(n, c, crop_h_ + h, crop_w_));
-        }
-      }
-    }
+    std::vector<int> indices(top[0]->num_axes(), 0);
+    crop_copy(bottom, top, offsets, indices, 0, top_diff, bottom_diff, false);
   }
 }
 

--- a/src/caffe/layers/crop_layer.cu
+++ b/src/caffe/layers/crop_layer.cu
@@ -1,0 +1,60 @@
+#include <vector>
+
+#include "caffe/layers/crop_layer.hpp"
+
+namespace caffe {
+
+// Copy (one line per thread) from one array to another, with arbitrary
+// strides in the last two dimensions.
+template <typename Dtype>
+__global__ void copy_kernel(const int n, const int height, const int width,
+    const int src_outer_stride, const int src_inner_stride,
+    const int dest_outer_stride, const int dest_inner_stride,
+    const Dtype* src, Dtype* dest) {
+  CUDA_KERNEL_LOOP(index, n) {
+    int src_start = index / height * src_outer_stride
+                  + index % height * src_inner_stride;
+    int dest_start = index / height * dest_outer_stride
+                   + index % height * dest_inner_stride;
+    for (int i = 0; i < width; ++i) {
+      dest[dest_start + i] = src[src_start + i];
+    }
+  }
+}
+
+template <typename Dtype>
+void CropLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top) {
+  const Dtype* bottom_data = bottom[0]->gpu_data();
+  Dtype* top_data = top[0]->mutable_gpu_data();
+  const int lines = top[0]->count() / top[0]->width();
+
+  // NOLINT_NEXT_LINE(whitespace/operators)
+  copy_kernel<<<CAFFE_GET_BLOCKS(lines), CAFFE_CUDA_NUM_THREADS>>>(
+      lines, top[0]->height(), top[0]->width(),
+      bottom[0]->height() * bottom[0]->width(), bottom[0]->width(),
+      top[0]->height() * top[0]->width(), top[0]->width(),
+      bottom_data + bottom[0]->offset(0, 0, crop_h_, crop_w_), top_data);
+}
+
+template <typename Dtype>
+void CropLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
+    const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+  const Dtype* top_diff = top[0]->gpu_diff();
+  Dtype* bottom_diff = bottom[0]->mutable_gpu_diff();
+  const int lines = top[0]->count() / top[0]->width();
+
+  if (propagate_down[0]) {
+    caffe_gpu_set(bottom[0]->count(), static_cast<Dtype>(0), bottom_diff);
+    // NOLINT_NEXT_LINE(whitespace/operators)
+    copy_kernel<<<CAFFE_GET_BLOCKS(lines), CAFFE_CUDA_NUM_THREADS>>>(
+        lines, top[0]->height(), top[0]->width(),
+        top[0]->height() * top[0]->width(), top[0]->width(),
+        bottom[0]->height() * bottom[0]->width(), bottom[0]->width(),
+        top_diff, bottom_diff + bottom[0]->offset(0, 0, crop_h_, crop_w_));
+  }
+}
+
+INSTANTIATE_LAYER_GPU_FUNCS(CropLayer);
+
+}  // namespace caffe

--- a/src/caffe/layers/crop_layer.cu
+++ b/src/caffe/layers/crop_layer.cu
@@ -100,9 +100,6 @@ template <typename Dtype>
 void CropLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
     const vector<Blob<Dtype>*>& top) {
   std::vector<int> indices(top[0]->num_axes(), 0);
-  // This works because crop_copy uses caffe_copy which calls cudaMemcpy.
-  // My intuition is that calling this thousands of times is probably less
-  // efficient than writing a custom kernel.
   const Dtype* bottom_data = bottom[0]->gpu_data();
   Dtype* top_data = top[0]->mutable_gpu_data();
   crop_copy_gpu(bottom, top, offsets, indices, 0, bottom_data, top_data, true);

--- a/src/caffe/layers/crop_layer.cu
+++ b/src/caffe/layers/crop_layer.cu
@@ -22,19 +22,90 @@ __global__ void copy_kernel(const int n, const int height, const int width,
   }
 }
 
+// recursive copy function, this function is similar to crop_copy but loops
+// over all but the last two dimensions. It is implemented this way to allow
+// for ND cropping while still relying on a CUDA kernel for the innermost
+// two dimensions for performance reasons.
+// An alternative way to implement ND cropping relying more on the kernel
+// would require passing offsets to the kernel, which is a bit problematic
+// because it is of variable length. Since in the standard (N,C,W,H) case
+// N,C are usually not cropped a speedup could be achieved by not looping
+// the application of the copy_kernel around these dimensions.
+template <typename Dtype>
+void CropLayer<Dtype>::crop_copy_gpu(const vector<Blob<Dtype>*>& bottom,
+             const vector<Blob<Dtype>*>& top,
+             const vector<int>& offsets,
+             vector<int> indices,
+             int cur_dim,
+             const Dtype* src_data,
+             Dtype* dest_data,
+             bool is_forward) {
+  if (cur_dim + 2 < top[0]->num_axes()) {
+    // We are not yet at the final dimension, call copy recursivley
+    for (int i = 0; i < top[0]->shape(cur_dim); ++i) {
+      indices[cur_dim] = i;
+      crop_copy_gpu(bottom, top, offsets, indices, cur_dim+1,
+                src_data, dest_data, is_forward);
+    }
+  } else {
+    // We are at the last two dimensions, which are stored continously in memory
+    // With (N,C,H,W)
+    //      (0,1,2,3) cur_dim   -> H
+    //                cur_dim+1 -> W
+    const int lines = top[0]->shape(cur_dim);
+    const int height = top[0]->shape(cur_dim);
+    const int width = top[0]->shape(cur_dim+1);
+    std::vector<int> ind_off(cur_dim+2, 0);
+    for (int j = 0; j < cur_dim; ++j) {
+        ind_off[j] = indices[j] + offsets[j];
+    }
+    ind_off[cur_dim] = offsets[cur_dim];
+    ind_off[cur_dim+1] = offsets[cur_dim+1];
+    // Compute copy strides
+    const int src_outer_stride =
+        bottom[0]->shape(cur_dim)*bottom[0]->shape(cur_dim+1);
+    const int src_inner_stride = bottom[0]->shape(cur_dim+1);
+    const int dest_outer_stride =
+        top[0]->shape(cur_dim)*top[0]->shape(cur_dim+1);
+    const int dest_inner_stride = top[0]->shape(cur_dim+1);
+
+    if (is_forward) {
+      const Dtype* bottom_data = bottom[0]->gpu_data() +
+          bottom[0]->offset(ind_off);
+      Dtype* top_data = top[0]->mutable_gpu_data() +
+          top[0]->offset(indices);
+      // NOLINT_NEXT_LINE(whitespace/operators)
+      copy_kernel<<<CAFFE_GET_BLOCKS(lines), CAFFE_CUDA_NUM_THREADS>>>(
+          lines, height, width,
+          src_outer_stride, src_inner_stride,
+          dest_outer_stride, dest_inner_stride,
+          bottom_data, top_data);
+
+    } else {
+      const Dtype* top_diff = top[0]->gpu_diff() +
+          top[0]->offset(indices);
+      Dtype* bottom_diff = bottom[0]->mutable_gpu_diff() +
+          bottom[0]->offset(ind_off);
+      // NOLINT_NEXT_LINE(whitespace/operators)
+      copy_kernel<<<CAFFE_GET_BLOCKS(lines), CAFFE_CUDA_NUM_THREADS>>>(
+          lines, height, width,
+          dest_outer_stride, dest_inner_stride,
+          src_outer_stride, src_inner_stride,
+          top_diff, bottom_diff);
+    }
+  }
+}
+
 template <typename Dtype>
 void CropLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
     const vector<Blob<Dtype>*>& top) {
+  std::vector<int> indices(top[0]->num_axes(), 0);
+  // This works because crop_copy uses caffe_copy which calls cudaMemcpy.
+  // My intuition is that calling this thousands of times is probably less
+  // efficient than writing a custom kernel.
   const Dtype* bottom_data = bottom[0]->gpu_data();
   Dtype* top_data = top[0]->mutable_gpu_data();
-  const int lines = top[0]->count() / top[0]->width();
-
-  // NOLINT_NEXT_LINE(whitespace/operators)
-  copy_kernel<<<CAFFE_GET_BLOCKS(lines), CAFFE_CUDA_NUM_THREADS>>>(
-      lines, top[0]->height(), top[0]->width(),
-      bottom[0]->height() * bottom[0]->width(), bottom[0]->width(),
-      top[0]->height() * top[0]->width(), top[0]->width(),
-      bottom_data + bottom[0]->offset(0, 0, crop_h_, crop_w_), top_data);
+  crop_copy_gpu(bottom, top, offsets, indices, 0, bottom_data, top_data, true);
 }
 
 template <typename Dtype>
@@ -42,16 +113,12 @@ void CropLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
     const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
   const Dtype* top_diff = top[0]->gpu_diff();
   Dtype* bottom_diff = bottom[0]->mutable_gpu_diff();
-  const int lines = top[0]->count() / top[0]->width();
 
   if (propagate_down[0]) {
     caffe_gpu_set(bottom[0]->count(), static_cast<Dtype>(0), bottom_diff);
-    // NOLINT_NEXT_LINE(whitespace/operators)
-    copy_kernel<<<CAFFE_GET_BLOCKS(lines), CAFFE_CUDA_NUM_THREADS>>>(
-        lines, top[0]->height(), top[0]->width(),
-        top[0]->height() * top[0]->width(), top[0]->width(),
-        bottom[0]->height() * bottom[0]->width(), bottom[0]->width(),
-        top_diff, bottom_diff + bottom[0]->offset(0, 0, crop_h_, crop_w_));
+    std::vector<int> indices(top[0]->num_axes(), 0);
+    crop_copy_gpu(bottom, top, offsets, indices, 0, top_diff, bottom_diff,
+                  false);
   }
 }
 

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -695,8 +695,10 @@ message CropParameter {
   // If only one `offset` is set, then all dimensions are offset by this amount.
   // Otherwise, the number of offsets must equal the number of cropped axes to
   // shift the crop in each dimension accordingly.
-  // Note: standard dimensions are N,C,H,W so the default is a spatial crop.
-  optional uint32 axis = 1 [default = 2];
+  // Note: standard dimensions are N,C,H,W so the default is a spatial crop,
+  // and `axis` may be negative to index from the end (e.g., -1 for the last
+  // axis).
+  optional int32 axis = 1 [default = 2];
   repeated uint32 offset = 2;
 }
 

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -685,10 +685,19 @@ message ConvolutionParameter {
 }
 
 message CropParameter {
-  // Assumes standard dimensions: ( N,C,H,W )
-  // This could possibly be extended to  use "optional BlobShape offsets"
-  optional uint32 offset_height = 1[default = 0];
-  optional uint32 offset_width = 2[default = 0];
+  // To crop, elements of the first bottom are selected to fit the dimensions
+  // of the second, reference bottom. The crop is configured by
+  // - the crop `axis` to pick the dimensions for cropping
+  // - the crop `offset` to set the shift for all/each dimension
+  // to align the cropped bottom with the reference bottom.
+  // All dimensions up to but excluding `axis` are preserved, while
+  // the dimensions including and trailing `axis` are cropped.
+  // If only one `offset` is set, then all dimensions are offset by this amount.
+  // Otherwise, the number of offsets must equal the number of cropped axes to
+  // shift the crop in each dimension accordingly.
+  // Note: standard dimensions are N,C,H,W so the default is a spatial crop.
+  optional uint32 axis = 1 [default = 2];
+  repeated uint32 offset = 2;
 }
 
 message DataParameter {
@@ -787,7 +796,7 @@ message EltwiseParameter {
 // Message that stores parameters used by ELULayer
 message ELUParameter {
   // Described in:
-  // Clevert, D.-A., Unterthiner, T., & Hochreiter, S. (2015). Fast and Accurate 
+  // Clevert, D.-A., Unterthiner, T., & Hochreiter, S. (2015). Fast and Accurate
   // Deep Network Learning by Exponential Linear Units (ELUs). arXiv
   optional float alpha = 1 [default = 1];
 }

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -364,7 +364,7 @@ message ParamSpec {
 // NOTE
 // Update the next available ID when you add a new LayerParameter field.
 //
-// LayerParameter next available layer-specific ID: 144 (last added: input_param)
+// LayerParameter next available layer-specific ID: 145 (last added: crop_param)
 message LayerParameter {
   optional string name = 1; // the layer name
   optional string type = 2; // the layer type
@@ -418,6 +418,7 @@ message LayerParameter {
   optional ConcatParameter concat_param = 104;
   optional ContrastiveLossParameter contrastive_loss_param = 105;
   optional ConvolutionParameter convolution_param = 106;
+  optional CropParameter crop_param = 144;
   optional DataParameter data_param = 107;
   optional DropoutParameter dropout_param = 108;
   optional DummyDataParameter dummy_data_param = 109;
@@ -681,6 +682,13 @@ message ConvolutionParameter {
   // implementation; for input blobs with num_axes != 2, this option is
   // ignored and the ND implementation will be used.)
   optional bool force_nd_im2col = 17 [default = false];
+}
+
+message CropParameter {
+  // Assumes standard dimensions: ( N,C,H,W )
+  // This could possibly be extended to  use "optional BlobShape offsets"
+  optional uint32 offset_height = 1[default = 0];
+  optional uint32 offset_width = 2[default = 0];
 }
 
 message DataParameter {

--- a/src/caffe/test/test_crop_layer.cpp
+++ b/src/caffe/test/test_crop_layer.cpp
@@ -1,0 +1,228 @@
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "caffe/blob.hpp"
+#include "caffe/common.hpp"
+#include "caffe/filler.hpp"
+#include "caffe/layers/crop_layer.hpp"
+
+#include "caffe/test/test_caffe_main.hpp"
+#include "caffe/test/test_gradient_check_util.hpp"
+
+namespace caffe {
+
+template <typename TypeParam>
+class CropLayerTest : public MultiDeviceTest<TypeParam> {
+  typedef typename TypeParam::Dtype Dtype;
+
+ protected:
+  CropLayerTest()
+      : blob_bottom_0_(new Blob<Dtype>(2, 5, 6, 5)),
+        blob_bottom_1_(new Blob<Dtype>(2, 4, 5, 3)),
+        blob_top_(new Blob<Dtype>()) {}
+  virtual void SetUp() {
+    // fill the values
+    for (int i = 0; i < this->blob_bottom_0_->count(); ++i) {
+      this->blob_bottom_0_->mutable_cpu_data()[i] = i;
+    }
+
+
+    blob_bottom_vec_0_.push_back(blob_bottom_0_);
+    blob_bottom_vec_0_.push_back(blob_bottom_1_);
+    blob_top_vec_.push_back(blob_top_);
+  }
+
+  virtual ~CropLayerTest() {
+    delete blob_bottom_0_; delete blob_bottom_1_;
+    delete blob_top_;
+  }
+
+  Blob<Dtype>* const blob_bottom_0_;
+  Blob<Dtype>* const blob_bottom_1_;
+  Blob<Dtype>* const blob_top_;
+  vector<Blob<Dtype>*> blob_bottom_vec_0_;
+  vector<Blob<Dtype>*> blob_top_vec_;
+};
+
+
+TYPED_TEST_CASE(CropLayerTest, TestDtypesAndDevices);
+
+TYPED_TEST(CropLayerTest, TestSetupShapeAll) {
+  typedef typename TypeParam::Dtype Dtype;
+  LayerParameter layer_param;
+
+  // Crop all dimensions
+  layer_param.mutable_crop_param()->set_axis(0);
+  CropLayer<Dtype> layer(layer_param);
+  layer.SetUp(this->blob_bottom_vec_0_, this->blob_top_vec_);
+  for (int i = 0; i < this->blob_top_->num_axes(); ++i) {
+    EXPECT_EQ(this->blob_bottom_1_->shape(i), this->blob_top_->shape(i));
+  }
+}
+
+TYPED_TEST(CropLayerTest, TestSetupShapeDefault) {
+  typedef typename TypeParam::Dtype Dtype;
+  LayerParameter layer_param;
+  // Crop last two dimensions, axis is 2 by default
+  CropLayer<Dtype> layer(layer_param);
+  layer.SetUp(this->blob_bottom_vec_0_, this->blob_top_vec_);
+  for (int i = 0; i < this->blob_top_->num_axes(); ++i) {
+    if (i < 2) {
+      EXPECT_EQ(this->blob_bottom_0_->shape(i), this->blob_top_->shape(i));
+    } else {
+      EXPECT_EQ(this->blob_bottom_1_->shape(i), this->blob_top_->shape(i));
+    }
+  }
+}
+
+TYPED_TEST(CropLayerTest, TestSetupShapeNegativeIndexing) {
+  typedef typename TypeParam::Dtype Dtype;
+  LayerParameter layer_param;
+  // Crop last dimension by negative indexing
+  layer_param.mutable_crop_param()->set_axis(-1);
+  CropLayer<Dtype> layer(layer_param);
+  layer.SetUp(this->blob_bottom_vec_0_, this->blob_top_vec_);
+  for (int i = 0; i < this->blob_top_->num_axes(); ++i) {
+    if (i < 3) {
+      EXPECT_EQ(this->blob_bottom_0_->shape(i), this->blob_top_->shape(i));
+    } else {
+      EXPECT_EQ(this->blob_bottom_1_->shape(i), this->blob_top_->shape(i));
+    }
+  }
+}
+
+
+TYPED_TEST(CropLayerTest, TestForwardNum) {
+  typedef typename TypeParam::Dtype Dtype;
+  LayerParameter layer_param;
+  layer_param.mutable_crop_param()->set_axis(0);
+
+  CropLayer<Dtype> layer(layer_param);
+  layer.SetUp(this->blob_bottom_vec_0_, this->blob_top_vec_);
+  layer.Forward(this->blob_bottom_vec_0_, this->blob_top_vec_);
+  for (int n = 0; n < this->blob_bottom_0_->num(); ++n) {
+    for (int c = 0; c < this->blob_bottom_0_->channels(); ++c) {
+      for (int h = 0; h < this->blob_bottom_0_->height(); ++h) {
+        for (int w = 0; w < this->blob_bottom_0_->width(); ++w) {
+          if ( n < this->blob_top_->shape(0) &&
+              c < this->blob_top_->shape(1) &&
+              h < this->blob_top_->shape(2) &&
+              w < this->blob_top_->shape(3) ) {
+            EXPECT_EQ(this->blob_top_->data_at(n, c, h, w),
+                this->blob_bottom_0_->data_at(n, c, h, w));
+          }
+        }
+      }
+    }
+  }
+}
+
+TYPED_TEST(CropLayerTest, TestForwardNumOffsets) {
+  typedef typename TypeParam::Dtype Dtype;
+  LayerParameter layer_param;
+  layer_param.mutable_crop_param()->set_axis(0);
+  layer_param.mutable_crop_param()->add_offset(0);
+  layer_param.mutable_crop_param()->add_offset(1);
+  layer_param.mutable_crop_param()->add_offset(1);
+  layer_param.mutable_crop_param()->add_offset(2);
+  CropLayer<Dtype> layer(layer_param);
+  layer.SetUp(this->blob_bottom_vec_0_, this->blob_top_vec_);
+  layer.Forward(this->blob_bottom_vec_0_, this->blob_top_vec_);
+  for (int n = 0; n < this->blob_bottom_0_->num(); ++n) {
+    for (int c = 0; c < this->blob_bottom_0_->channels(); ++c) {
+      for (int h = 0; h < this->blob_bottom_0_->height(); ++h) {
+        for (int w = 0; w < this->blob_bottom_0_->width(); ++w) {
+          if ( n < this->blob_top_->shape(0) &&
+              c < this->blob_top_->shape(1) &&
+              h < this->blob_top_->shape(2) &&
+              w < this->blob_top_->shape(3) ) {
+            EXPECT_EQ(this->blob_top_->data_at(n, c, h, w),
+                this->blob_bottom_0_->data_at(n+0, c+1, h+1, w+2));
+          }
+        }
+      }
+    }
+  }
+}
+
+TYPED_TEST(CropLayerTest, TestGradientNum) {
+  typedef typename TypeParam::Dtype Dtype;
+  LayerParameter layer_param;
+  CropLayer<Dtype> layer(layer_param);
+
+  layer.SetUp(this->blob_bottom_vec_0_, this->blob_top_vec_);
+  layer.Forward(this->blob_bottom_vec_0_, this->blob_top_vec_);
+
+  // Copy top data into diff
+  caffe_copy(this->blob_top_->count(), this->blob_top_->cpu_data(),
+             this->blob_top_->mutable_cpu_diff());
+
+  // Do backward pass
+  vector<bool> propagate_down(2, true);
+  layer.Backward(this->blob_top_vec_, propagate_down, this->blob_bottom_vec_0_);
+
+
+  // Check results
+  for (int n = 0; n < this->blob_bottom_0_->num(); ++n) {
+    for (int c = 0; c < this->blob_bottom_0_->channels(); ++c) {
+      for (int h = 0; h < this->blob_bottom_0_->height(); ++h) {
+        for (int w = 0; w < this->blob_bottom_0_->width(); ++w) {
+          if ( n < this->blob_top_->shape(0) &&
+              c < this->blob_top_->shape(1) &&
+              h < this->blob_top_->shape(2) &&
+              w < this->blob_top_->shape(3) ) {
+            EXPECT_EQ(this->blob_bottom_0_->diff_at(n, c, h, w),
+                      this->blob_bottom_0_->data_at(n, c, h, w));
+          } else {
+            EXPECT_EQ(this->blob_bottom_0_->diff_at(n, c, h, w), 0);
+          }
+        }
+      }
+    }
+  }
+}
+
+TYPED_TEST(CropLayerTest, TestGradientNumOffset) {
+  typedef typename TypeParam::Dtype Dtype;
+  LayerParameter layer_param;
+  layer_param.mutable_crop_param()->set_axis(0);
+  layer_param.mutable_crop_param()->add_offset(0);
+  layer_param.mutable_crop_param()->add_offset(1);
+  layer_param.mutable_crop_param()->add_offset(1);
+  layer_param.mutable_crop_param()->add_offset(2);
+  CropLayer<Dtype> layer(layer_param);
+
+  layer.SetUp(this->blob_bottom_vec_0_, this->blob_top_vec_);
+  layer.Forward(this->blob_bottom_vec_0_, this->blob_top_vec_);
+
+  // Copy top data into diff
+  caffe_copy(this->blob_top_->count(), this->blob_top_->cpu_data(),
+             this->blob_top_->mutable_cpu_diff());
+
+  // Do backward pass
+  vector<bool> propagate_down(2, true);
+  layer.Backward(this->blob_top_vec_, propagate_down, this->blob_bottom_vec_0_);
+
+
+  // Check results
+  for (int n = 0; n < this->blob_bottom_0_->num(); ++n) {
+    for (int c = 0; c < this->blob_bottom_0_->channels(); ++c) {
+      for (int h = 0; h < this->blob_bottom_0_->height(); ++h) {
+        for (int w = 0; w < this->blob_bottom_0_->width(); ++w) {
+          if ( 0 <= n && n < 0 + this->blob_top_->shape(0) &&
+              1 <= c && c < 1 + this->blob_top_->shape(1) &&
+              1 <= h && h < 1 + this->blob_top_->shape(2) &&
+              2 <= w && w < 2 + this->blob_top_->shape(3) ) {
+            EXPECT_EQ(this->blob_bottom_0_->diff_at(n, c, h, w),
+                      this->blob_bottom_0_->data_at(n, c, h, w));
+          } else {
+            EXPECT_EQ(this->blob_bottom_0_->diff_at(n, c, h, w), 0);
+          }
+        }
+      }
+    }
+  }
+}
+
+}  // namespace caffe

--- a/src/caffe/test/test_crop_layer.cpp
+++ b/src/caffe/test/test_crop_layer.cpp
@@ -18,18 +18,18 @@ class CropLayerTest : public MultiDeviceTest<TypeParam> {
 
  protected:
   CropLayerTest()
-      : blob_bottom_0_(new Blob<Dtype>(2, 5, 6, 5)),
-        blob_bottom_1_(new Blob<Dtype>(2, 4, 5, 3)),
+      : blob_bottom_0_(new Blob<Dtype>(2, 4, 5, 4)),
+        blob_bottom_1_(new Blob<Dtype>(2, 3, 4, 2)),
         blob_top_(new Blob<Dtype>()) {}
   virtual void SetUp() {
     // fill the values
-    for (int i = 0; i < this->blob_bottom_0_->count(); ++i) {
-      this->blob_bottom_0_->mutable_cpu_data()[i] = i;
-    }
+    FillerParameter filler_param;
+    GaussianFiller<Dtype> filler(filler_param);
+    filler.Fill(this->blob_bottom_0_);
+    filler.Fill(this->blob_bottom_1_);
 
-
-    blob_bottom_vec_0_.push_back(blob_bottom_0_);
-    blob_bottom_vec_0_.push_back(blob_bottom_1_);
+    blob_bottom_vec_.push_back(blob_bottom_0_);
+    blob_bottom_vec_.push_back(blob_bottom_1_);
     blob_top_vec_.push_back(blob_top_);
   }
 
@@ -41,7 +41,7 @@ class CropLayerTest : public MultiDeviceTest<TypeParam> {
   Blob<Dtype>* const blob_bottom_0_;
   Blob<Dtype>* const blob_bottom_1_;
   Blob<Dtype>* const blob_top_;
-  vector<Blob<Dtype>*> blob_bottom_vec_0_;
+  vector<Blob<Dtype>*> blob_bottom_vec_;
   vector<Blob<Dtype>*> blob_top_vec_;
 };
 
@@ -51,11 +51,10 @@ TYPED_TEST_CASE(CropLayerTest, TestDtypesAndDevices);
 TYPED_TEST(CropLayerTest, TestSetupShapeAll) {
   typedef typename TypeParam::Dtype Dtype;
   LayerParameter layer_param;
-
   // Crop all dimensions
   layer_param.mutable_crop_param()->set_axis(0);
   CropLayer<Dtype> layer(layer_param);
-  layer.SetUp(this->blob_bottom_vec_0_, this->blob_top_vec_);
+  layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
   for (int i = 0; i < this->blob_top_->num_axes(); ++i) {
     EXPECT_EQ(this->blob_bottom_1_->shape(i), this->blob_top_->shape(i));
   }
@@ -66,7 +65,7 @@ TYPED_TEST(CropLayerTest, TestSetupShapeDefault) {
   LayerParameter layer_param;
   // Crop last two dimensions, axis is 2 by default
   CropLayer<Dtype> layer(layer_param);
-  layer.SetUp(this->blob_bottom_vec_0_, this->blob_top_vec_);
+  layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
   for (int i = 0; i < this->blob_top_->num_axes(); ++i) {
     if (i < 2) {
       EXPECT_EQ(this->blob_bottom_0_->shape(i), this->blob_top_->shape(i));
@@ -82,7 +81,7 @@ TYPED_TEST(CropLayerTest, TestSetupShapeNegativeIndexing) {
   // Crop last dimension by negative indexing
   layer_param.mutable_crop_param()->set_axis(-1);
   CropLayer<Dtype> layer(layer_param);
-  layer.SetUp(this->blob_bottom_vec_0_, this->blob_top_vec_);
+  layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
   for (int i = 0; i < this->blob_top_->num_axes(); ++i) {
     if (i < 3) {
       EXPECT_EQ(this->blob_bottom_0_->shape(i), this->blob_top_->shape(i));
@@ -92,15 +91,13 @@ TYPED_TEST(CropLayerTest, TestSetupShapeNegativeIndexing) {
   }
 }
 
-
-TYPED_TEST(CropLayerTest, TestForwardNum) {
+TYPED_TEST(CropLayerTest, TestCropAll) {
   typedef typename TypeParam::Dtype Dtype;
   LayerParameter layer_param;
   layer_param.mutable_crop_param()->set_axis(0);
-
   CropLayer<Dtype> layer(layer_param);
-  layer.SetUp(this->blob_bottom_vec_0_, this->blob_top_vec_);
-  layer.Forward(this->blob_bottom_vec_0_, this->blob_top_vec_);
+  layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+  layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
   for (int n = 0; n < this->blob_bottom_0_->num(); ++n) {
     for (int c = 0; c < this->blob_bottom_0_->channels(); ++c) {
       for (int h = 0; h < this->blob_bottom_0_->height(); ++h) {
@@ -118,7 +115,7 @@ TYPED_TEST(CropLayerTest, TestForwardNum) {
   }
 }
 
-TYPED_TEST(CropLayerTest, TestForwardNumOffsets) {
+TYPED_TEST(CropLayerTest, TestCropAllOffset) {
   typedef typename TypeParam::Dtype Dtype;
   LayerParameter layer_param;
   layer_param.mutable_crop_param()->set_axis(0);
@@ -127,8 +124,8 @@ TYPED_TEST(CropLayerTest, TestForwardNumOffsets) {
   layer_param.mutable_crop_param()->add_offset(1);
   layer_param.mutable_crop_param()->add_offset(2);
   CropLayer<Dtype> layer(layer_param);
-  layer.SetUp(this->blob_bottom_vec_0_, this->blob_top_vec_);
-  layer.Forward(this->blob_bottom_vec_0_, this->blob_top_vec_);
+  layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+  layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
   for (int n = 0; n < this->blob_bottom_0_->num(); ++n) {
     for (int c = 0; c < this->blob_bottom_0_->channels(); ++c) {
       for (int h = 0; h < this->blob_bottom_0_->height(); ++h) {
@@ -138,7 +135,7 @@ TYPED_TEST(CropLayerTest, TestForwardNumOffsets) {
               h < this->blob_top_->shape(2) &&
               w < this->blob_top_->shape(3) ) {
             EXPECT_EQ(this->blob_top_->data_at(n, c, h, w),
-                this->blob_bottom_0_->data_at(n+0, c+1, h+1, w+2));
+                this->blob_bottom_0_->data_at(n, c+1, h+1, w+2));
           }
         }
       }
@@ -146,83 +143,123 @@ TYPED_TEST(CropLayerTest, TestForwardNumOffsets) {
   }
 }
 
-TYPED_TEST(CropLayerTest, TestGradientNum) {
+TYPED_TEST(CropLayerTest, TestCropHW) {
   typedef typename TypeParam::Dtype Dtype;
   LayerParameter layer_param;
-  CropLayer<Dtype> layer(layer_param);
-
-  layer.SetUp(this->blob_bottom_vec_0_, this->blob_top_vec_);
-  layer.Forward(this->blob_bottom_vec_0_, this->blob_top_vec_);
-
-  // Copy top data into diff
-  caffe_copy(this->blob_top_->count(), this->blob_top_->cpu_data(),
-             this->blob_top_->mutable_cpu_diff());
-
-  // Do backward pass
-  vector<bool> propagate_down(2, true);
-  layer.Backward(this->blob_top_vec_, propagate_down, this->blob_bottom_vec_0_);
-
-
-  // Check results
-  for (int n = 0; n < this->blob_bottom_0_->num(); ++n) {
-    for (int c = 0; c < this->blob_bottom_0_->channels(); ++c) {
-      for (int h = 0; h < this->blob_bottom_0_->height(); ++h) {
-        for (int w = 0; w < this->blob_bottom_0_->width(); ++w) {
-          if ( n < this->blob_top_->shape(0) &&
-              c < this->blob_top_->shape(1) &&
-              h < this->blob_top_->shape(2) &&
-              w < this->blob_top_->shape(3) ) {
-            EXPECT_EQ(this->blob_bottom_0_->diff_at(n, c, h, w),
-                      this->blob_bottom_0_->data_at(n, c, h, w));
-          } else {
-            EXPECT_EQ(this->blob_bottom_0_->diff_at(n, c, h, w), 0);
-          }
-        }
-      }
-    }
-  }
-}
-
-TYPED_TEST(CropLayerTest, TestGradientNumOffset) {
-  typedef typename TypeParam::Dtype Dtype;
-  LayerParameter layer_param;
-  layer_param.mutable_crop_param()->set_axis(0);
-  layer_param.mutable_crop_param()->add_offset(0);
-  layer_param.mutable_crop_param()->add_offset(1);
+  layer_param.mutable_crop_param()->set_axis(2);
   layer_param.mutable_crop_param()->add_offset(1);
   layer_param.mutable_crop_param()->add_offset(2);
   CropLayer<Dtype> layer(layer_param);
-
-  layer.SetUp(this->blob_bottom_vec_0_, this->blob_top_vec_);
-  layer.Forward(this->blob_bottom_vec_0_, this->blob_top_vec_);
-
-  // Copy top data into diff
-  caffe_copy(this->blob_top_->count(), this->blob_top_->cpu_data(),
-             this->blob_top_->mutable_cpu_diff());
-
-  // Do backward pass
-  vector<bool> propagate_down(2, true);
-  layer.Backward(this->blob_top_vec_, propagate_down, this->blob_bottom_vec_0_);
-
-
-  // Check results
+  layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+  layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
   for (int n = 0; n < this->blob_bottom_0_->num(); ++n) {
     for (int c = 0; c < this->blob_bottom_0_->channels(); ++c) {
       for (int h = 0; h < this->blob_bottom_0_->height(); ++h) {
         for (int w = 0; w < this->blob_bottom_0_->width(); ++w) {
-          if ( 0 <= n && n < 0 + this->blob_top_->shape(0) &&
-              1 <= c && c < 1 + this->blob_top_->shape(1) &&
-              1 <= h && h < 1 + this->blob_top_->shape(2) &&
-              2 <= w && w < 2 + this->blob_top_->shape(3) ) {
-            EXPECT_EQ(this->blob_bottom_0_->diff_at(n, c, h, w),
-                      this->blob_bottom_0_->data_at(n, c, h, w));
-          } else {
-            EXPECT_EQ(this->blob_bottom_0_->diff_at(n, c, h, w), 0);
+          if (n < this->blob_top_->shape(0) &&
+              c < this->blob_top_->shape(1) &&
+              h < this->blob_top_->shape(2) &&
+              w < this->blob_top_->shape(3)) {
+            EXPECT_EQ(this->blob_top_->data_at(n, c, h, w),
+                this->blob_bottom_0_->data_at(n, c, h+1, w+2));
           }
         }
       }
     }
   }
+}
+
+TYPED_TEST(CropLayerTest, TestCrop5D) {
+  typedef typename TypeParam::Dtype Dtype;
+  // Add dimension to each bottom for >4D check
+  vector<int> bottom_0_shape = this->blob_bottom_0_->shape();
+  vector<int> bottom_1_shape = this->blob_bottom_1_->shape();
+  bottom_0_shape.push_back(2);
+  bottom_1_shape.push_back(1);
+  this->blob_bottom_0_->Reshape(bottom_0_shape);
+  this->blob_bottom_1_->Reshape(bottom_1_shape);
+  FillerParameter filler_param;
+  GaussianFiller<Dtype> filler(filler_param);
+  filler.Fill(this->blob_bottom_0_);
+  filler.Fill(this->blob_bottom_1_);
+  // Make layer
+  LayerParameter layer_param;
+  layer_param.mutable_crop_param()->set_axis(2);
+  layer_param.mutable_crop_param()->add_offset(1);
+  layer_param.mutable_crop_param()->add_offset(2);
+  layer_param.mutable_crop_param()->add_offset(0);
+  CropLayer<Dtype> layer(layer_param);
+  layer.SetUp(this->blob_bottom_vec_, this->blob_top_vec_);
+  layer.Forward(this->blob_bottom_vec_, this->blob_top_vec_);
+  vector<int> bottom_idx = vector<int>(5, 0);
+  vector<int> top_idx = vector<int>(5, 0);
+  for (int n = 0; n < this->blob_bottom_0_->shape(0); ++n) {
+    for (int c = 0; c < this->blob_bottom_0_->shape(1); ++c) {
+      for (int z = 0; z < this->blob_bottom_0_->shape(2); ++z) {
+        for (int h = 0; h < this->blob_bottom_0_->shape(3); ++h) {
+          for (int w = 0; w < this->blob_bottom_0_->shape(4); ++w) {
+            if (n < this->blob_top_->shape(0) &&
+                c < this->blob_top_->shape(1) &&
+                z < this->blob_top_->shape(2) &&
+                h < this->blob_top_->shape(3) &&
+                w < this->blob_top_->shape(4)) {
+              bottom_idx[0] = top_idx[0] = n;
+              bottom_idx[1] = top_idx[1] = c;
+              bottom_idx[2] = z;
+              bottom_idx[3] = h;
+              bottom_idx[4] = top_idx[4] = w;
+              top_idx[2] = z+1;
+              top_idx[3] = h+2;
+              EXPECT_EQ(this->blob_top_->data_at(bottom_idx),
+                  this->blob_bottom_0_->data_at(top_idx));
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+TYPED_TEST(CropLayerTest, TestCropAllGradient) {
+  typedef typename TypeParam::Dtype Dtype;
+  LayerParameter layer_param;
+  layer_param.mutable_crop_param()->set_axis(0);
+  CropLayer<Dtype> layer(layer_param);
+  GradientChecker<Dtype> checker(1e-2, 1e-3);
+  checker.CheckGradientExhaustive(&layer, this->blob_bottom_vec_,
+      this->blob_top_vec_);
+}
+
+TYPED_TEST(CropLayerTest, TestCropHWGradient) {
+  typedef typename TypeParam::Dtype Dtype;
+  LayerParameter layer_param;
+  layer_param.mutable_crop_param()->set_axis(2);
+  layer_param.mutable_crop_param()->add_offset(1);
+  layer_param.mutable_crop_param()->add_offset(2);
+  CropLayer<Dtype> layer(layer_param);
+  GradientChecker<Dtype> checker(1e-2, 1e-3);
+  checker.CheckGradientExhaustive(&layer, this->blob_bottom_vec_,
+      this->blob_top_vec_);
+}
+
+TYPED_TEST(CropLayerTest, TestCrop5DGradient) {
+  typedef typename TypeParam::Dtype Dtype;
+  LayerParameter layer_param;
+  layer_param.mutable_crop_param()->set_axis(2);
+  layer_param.mutable_crop_param()->add_offset(1);
+  layer_param.mutable_crop_param()->add_offset(2);
+  layer_param.mutable_crop_param()->add_offset(0);
+  CropLayer<Dtype> layer(layer_param);
+  // Add dimension to each bottom for >4D check
+  vector<int> bottom_0_shape = this->blob_bottom_0_->shape();
+  vector<int> bottom_1_shape = this->blob_bottom_1_->shape();
+  bottom_0_shape.push_back(2);
+  bottom_1_shape.push_back(1);
+  this->blob_bottom_0_->Reshape(bottom_0_shape);
+  this->blob_bottom_1_->Reshape(bottom_1_shape);
+  GradientChecker<Dtype> checker(1e-2, 1e-3);
+  checker.CheckGradientExhaustive(&layer, this->blob_bottom_vec_,
+      this->blob_top_vec_);
 }
 
 }  // namespace caffe


### PR DESCRIPTION
Now that [FCN](https://github.com/shelhamer/fcn.berkeleyvision.org) became compatible with BVLC/caffe master, I would like intelcaffe to reflect required changes.

They are only the following two PRs, and each of which contains 4 commits. Fortunately, they are only additions of Crop layers.

[#3613 Python/net spec coordinate map and crop computation](https://github.com/BVLC/caffe/pull/3613/commits)
[#3570 ND Crop layer](https://github.com/BVLC/caffe/pull/3570/commits)

I confirmed _make runtest_ and a single FCN inference with voc-fcn8s and voc-fcn-alexnet works fine on the following environment without USE_MKL2017_AS_DEFAULT_ENGINE. If enabled, it has experienced very bad performance, and produces a wrong output. I will file this later.

CPU
```
$ lscpu
Architecture:          x86_64
CPU op-mode(s):        32-bit, 64-bit
Byte Order:            Little Endian
CPU(s):                56
On-line CPU(s) list:   0-55
Thread(s) per core:    2
Core(s) per socket:    14
Socket(s):             2
NUMA node(s):          2
Vendor ID:             GenuineIntel
CPU family:            6
Model:                 79
Stepping:              1
CPU MHz:               1200.312
BogoMIPS:              3992.07
Virtualization:        VT-x
L1d cache:             32K
L1i cache:             32K
L2 cache:              256K
L3 cache:              35840K
NUMA node0 CPU(s):     0-13,28-41
NUMA node1 CPU(s):     14-27,42-55
```
OS
```
$ lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 14.04.3 LTS
Release:	14.04
Codename:	trusty
```
MKL
```
$ env | grep -i MKL
MKLROOT=/opt/intel/compilers_and_libraries_2017.0.064/linux/mkl
LIBRARY_PATH=/opt/intel/compilers_and_libraries_2017.0.064/linux/tbb/lib/intel64/gcc4.4:/opt/intel/compilers_and_libraries_2017.0.064/linux/compiler/lib/intel64:/opt/intel/compilers_and_libraries_2017.0.064/linux/mkl/lib/intel64
MIC_LD_LIBRARY_PATH=/opt/intel/compilers_and_libraries_2017.0.064/linux/tbb/lib/mic:/opt/intel/compilers_and_libraries_2017.0.064/linux/compiler/lib/mic:/opt/intel/compilers_and_libraries_2017.0.064/linux/mkl/lib/mic
LD_LIBRARY_PATH=/opt/intel/compilers_and_libraries_2017.0.064/linux/tbb/lib/intel64/gcc4.4:/opt/intel/compilers_and_libraries_2017.0.064/linux/compiler/lib/intel64:/opt/intel/compilers_and_libraries_2017.0.064/linux/mkl/lib/intel64
CPATH=/opt/intel/compilers_and_libraries_2017.0.064/linux/mkl/include
NLSPATH=/opt/intel/compilers_and_libraries_2017.0.064/linux/mkl/lib/intel64/locale/%l_%t/%N
```